### PR TITLE
Sync during dd and do not show progress

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,8 +22,8 @@
       '{{ (device_files_obj.stdout|from_json).blockdevices }}'
 
 - name: ensure image written to disk
-  command: 'dd "if={{ pi_er_image_file }}" bs=1M status=progress
-           "of={{ pi_er_sd_device }}" oflag=sync'
+  command: 'dd "if={{ pi_er_image_file }}" bs=1M
+           "of={{ pi_er_sd_device }}" conv=fsync'
   become: yes
 
 - name: ensure filesystem synced


### PR DESCRIPTION
This commit fixes the dd invocation so that disk syncing now occurs
during the operation. This commit also ensures that dd does not attempt
to show progress, as even when running with debug, this offers almost no
value and is potentially spammy.